### PR TITLE
fix  getAssetsPath function

### DIFF
--- a/wp-composer-dependencies/wpcli.php
+++ b/wp-composer-dependencies/wpcli.php
@@ -1652,9 +1652,7 @@ class WPCLI
 	public function getAssetsPath($path = '')
 	{
 		if (empty($path)) {
-			ob_start();
-			$path = \WP_CLI::run_command(['plugin', 'path'], [], ['quiet']);
-			$path = ob_get_clean();
+			$path = \WP_CLI::runcommand( 'plugin path', [ 'return' => true, 'launch' => true, 'exit_error' => true, 'parse' => false ] );
 		}
 
 		return @dirname($path);


### PR DESCRIPTION
I don't know exactly why, but in my envirnoment ( php 7.3, WP-CLI 2.4 ) this function
```
$path = \WP_CLI::run_command(['plugin', 'path'], [], ['quiet']);
```
works indefinitely
